### PR TITLE
fix: Replace Devantler.CLIRunner with CLIWrap for command execution improvements

### DIFF
--- a/src/Devantler.FluxCLI/Devantler.FluxCLI.csproj
+++ b/src/Devantler.FluxCLI/Devantler.FluxCLI.csproj
@@ -12,8 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devantler.CLIRunner" Version="1.0.38" />
-    <PackageReference Include="IdentityModel" Version="7.0.0" />
+    <PackageReference Include="CLIWrap" Version="3.8.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Devantler.FluxCLI/Flux.cs
+++ b/src/Devantler.FluxCLI/Flux.cs
@@ -1,6 +1,6 @@
 ﻿using System.Runtime.InteropServices;
 using CliWrap;
-
+using CliWrap.Buffered;
 using Devantler.CLIRunner;
 
 namespace Devantler.FluxCLI;
@@ -58,11 +58,13 @@ public static class Flux
     bool includeStdErr = true,
     CancellationToken cancellationToken = default)
   {
-    return await CLI.RunAsync(
-      Command.WithArguments(arguments),
-      validation: validation,
-      silent: silent,
-      includeStdErr: includeStdErr,
-      cancellationToken: cancellationToken).ConfigureAwait(false);
+    using var stdOut = Console.OpenStandardInput();
+    using var stdErr = Console.OpenStandardError();
+    var command = Command.WithArguments(arguments)
+      .WithValidation(validation)
+      .WithStandardOutputPipe(silent ? PipeTarget.Null : PipeTarget.ToStream(stdOut))
+      .WithStandardErrorPipe(silent || !includeStdErr ? PipeTarget.Null : PipeTarget.ToStream(stdErr));
+    var result = await command.ExecuteBufferedAsync(cancellationToken);
+    return (result.ExitCode, result.StandardOutput + result.StandardError);
   }
 }

--- a/src/Devantler.FluxCLI/Flux.cs
+++ b/src/Devantler.FluxCLI/Flux.cs
@@ -57,10 +57,12 @@ public static class Flux
     bool includeStdErr = true,
     CancellationToken cancellationToken = default)
   {
-    using var stdOut = Console.OpenStandardInput();
+    using var stdIn = Console.OpenStandardInput();
+    using var stdOut = Console.OpenStandardOutput();
     using var stdErr = Console.OpenStandardError();
     var command = Command.WithArguments(arguments)
       .WithValidation(validation)
+      .WithStandardInputPipe(silent ? PipeSource.Null : PipeSource.FromStream(stdIn))
       .WithStandardOutputPipe(silent ? PipeTarget.Null : PipeTarget.ToStream(stdOut))
       .WithStandardErrorPipe(silent || !includeStdErr ? PipeTarget.Null : PipeTarget.ToStream(stdErr));
     var result = await command.ExecuteBufferedAsync(cancellationToken);

--- a/src/Devantler.FluxCLI/Flux.cs
+++ b/src/Devantler.FluxCLI/Flux.cs
@@ -1,7 +1,6 @@
 ﻿using System.Runtime.InteropServices;
 using CliWrap;
 using CliWrap.Buffered;
-using Devantler.CLIRunner;
 
 namespace Devantler.FluxCLI;
 


### PR DESCRIPTION
Replace the Devantler.CLIRunner package with CLIWrap and update the command execution logic to enhance performance and error handling.