### PR TITLE
fix: update OS version check for Windows compatibility

### DIFF
--- a/src/DevantlerTech.FluxCLI/Flux.cs
+++ b/src/DevantlerTech.FluxCLI/Flux.cs
@@ -15,7 +15,7 @@ public static class Flux
   {
     get
     {
-      string binaryName = Environment.OSVersion.Platform == PlatformID.Win32NT ? "flux.exe" : "flux";
+      string binaryName = OperatingSystem.IsWindows() ? "flux.exe" : "flux";
       string? pathEnv = Environment.GetEnvironmentVariable("PATH");
 
       if (!string.IsNullOrEmpty(pathEnv))


### PR DESCRIPTION
Replace the deprecated `Environment.OSVersion.Platform` check with `OperatingSystem.IsWindows()` for improved compatibility and clarity.